### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Demos/dplyr/hands_on_with_dplyr.md
+++ b/Demos/dplyr/hands_on_with_dplyr.md
@@ -845,7 +845,7 @@ Here are some additional functions which can be used with summarise.
 ![](images/summarise_2.png)
 
 *****
-##Group_by
+## Group_by
 Break the data sets into groups of rows.
 
 ![](images/group_by.png)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Bioinformatics related demos and tutorials using the R programming language.
 * [Building Biochemical and Chemical Similarity Networks](https://github.com/dgrapov/TeachingDemos/wiki/Biochemical-and-Chemical-Similarity-Networks) (advanced)
 * [KEGG Pathway Visualization] (https://github.com/dgrapov/TeachingDemos/blob/master/Demos/Pathway%20Analysis/KEGG%20Pathway%20Enrichment.md) (genes, proteins and metabolites)
 
-##Miscellaneous
+## Miscellaneous
 * [Summer 2014 Metabolomic Data Analysis Workshop] (http://imdevsoftware.wordpress.com/2013/09/08/sessions-in-metabolomics-2013/)
 * [Winter 2014 Metabolomic Data Analysis Workshop](http://imdevsoftware.wordpress.com/2014/02/17/tutorials-statistical-and-multivariate-analysis-for-metabolomics/)
 * [Data analysis and visualization blog](http://imdevsoftware.wordpress.com/category/uncategorized/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
